### PR TITLE
Add Property#show endpoint

### DIFF
--- a/app/controllers/api/v1/properties_controller.rb
+++ b/app/controllers/api/v1/properties_controller.rb
@@ -8,6 +8,12 @@ module Api
 
         render json: @properties.to_json
       end
+
+      def show
+        @property = Property.for_reference(params[:id])
+
+        render json: @property.to_json
+      end
     end
   end
 end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -18,6 +18,13 @@ class Property
       response.map { |r| build(r) }
     end
 
+    def for_reference(reference)
+      response = PlatformApis::Properties::Client.
+        get_property_by_reference(reference)
+
+      build(response)
+    end
+
     def build(attributes)
       new(
         propertyReference: attributes["propRef"]&.strip,

--- a/app/services/platform_apis/properties/client.rb
+++ b/app/services/platform_apis/properties/client.rb
@@ -12,6 +12,10 @@ module PlatformApis
           request.retrieve("properties?postcode=#{postcode}")
         end
 
+        def get_property_by_reference(reference)
+          request.retrieve("properties/#{reference}")
+        end
+
       private
 
         def request

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :properties, only: [:index]
+      resources :properties, only: [:index, :show]
     end
   end
 end

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -65,6 +65,27 @@ RSpec.describe Property do
     end
   end
 
+  describe ".for_reference" do
+    let(:reference) { "100023022310" }
+
+    it "returns a single property object built from the API client response" do
+      allow(PlatformApis::Properties::Client).to receive(
+        :get_property_by_reference
+      ).with(reference).and_return(
+        property_attributes_1
+      )
+
+      property = described_class.for_reference(reference)
+
+      expect(property.propertyReference).to eq "100023022310"
+      expect(property.address.postalCode).to eq("E9 6PT")
+      expect(property.address.shortAddress).to eq("16 Pitcairn House  St Thomass Square")
+      expect(property.hierarchyType.levelCode).to eq("7")
+      expect(property.hierarchyType.subTypeCode).to eq("DWE")
+      expect(property.hierarchyType.subTypeDescription).to eq("Dwelling")
+    end
+  end
+
   describe ".build" do
     it "builds a new property and child models with supplied attributes" do
       expect(Address).to receive(:build).once.with(property_attributes_1)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,8 @@ end
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
 
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+
 begin
   ActiveRecord::Migration.maintain_test_schema!
 rescue ActiveRecord::PendingMigrationError => e

--- a/spec/requests/properties_spec.rb
+++ b/spec/requests/properties_spec.rb
@@ -122,6 +122,46 @@ RSpec.describe "Properties" do
     end
   end
 
+  describe "show" do
+    context "when searching by postcode" do
+      before do
+        stub_property_request(
+          reference: "100023022310",
+          response_body:
+            {
+              propRef: "100023022310",
+              address1: "1 Example Road",
+              postCode: "A1 1AA",
+              levelCode: "1",
+              subtypCode: "DWE"
+            },
+          status: 200
+        )
+
+        get("/api/v1/properties/100023022310")
+      end
+
+      it "returns a JSON representation from a single property" do
+        parsed_response = JSON.parse(response.body)
+
+        expect(parsed_response).to eq(
+          {
+            "propertyReference" => "100023022310",
+            "address" => {
+              "shortAddress" => "1 Example Road",
+              "postalCode" => "A1 1AA"
+            },
+            "hierarchyType" => {
+              "levelCode" => "1",
+              "subTypeCode" => "DWE",
+              "subTypeDescription" => "Dwelling"
+            }
+          }
+        )
+      end
+    end
+  end
+
   def stub_properties_request(query_params:, response_body:, status:)
     stub_request(
       :get,
@@ -129,6 +169,18 @@ RSpec.describe "Properties" do
     ).with(
       headers: { "X-Api-Key" => Rails.application.credentials.platform_apis[:properties][:x_api_key] },
       query:   query_params
+    ).to_return(
+      body: JSON.generate(response_body),
+      status: status
+    )
+  end
+
+  def stub_property_request(reference:, response_body:, status:)
+    stub_request(
+      :get,
+      "#{Rails.application.credentials.platform_apis[:properties][:url]}properties/#{reference}"
+    ).with(
+      headers: { "X-Api-Key" => Rails.application.credentials.platform_apis[:properties][:x_api_key] },
     ).to_return(
       body: JSON.generate(response_body),
       status: status

--- a/spec/requests/properties_spec.rb
+++ b/spec/requests/properties_spec.rb
@@ -161,29 +161,4 @@ RSpec.describe "Properties" do
       end
     end
   end
-
-  def stub_properties_request(query_params:, response_body:, status:)
-    stub_request(
-      :get,
-      "#{Rails.application.credentials.platform_apis[:properties][:url]}properties"
-    ).with(
-      headers: { "X-Api-Key" => Rails.application.credentials.platform_apis[:properties][:x_api_key] },
-      query:   query_params
-    ).to_return(
-      body: JSON.generate(response_body),
-      status: status
-    )
-  end
-
-  def stub_property_request(reference:, response_body:, status:)
-    stub_request(
-      :get,
-      "#{Rails.application.credentials.platform_apis[:properties][:url]}properties/#{reference}"
-    ).with(
-      headers: { "X-Api-Key" => Rails.application.credentials.platform_apis[:properties][:x_api_key] },
-    ).to_return(
-      body: JSON.generate(response_body),
-      status: status
-    )
-  end
 end

--- a/spec/services/platform_apis/properties/client_spec.rb
+++ b/spec/services/platform_apis/properties/client_spec.rb
@@ -24,4 +24,12 @@ RSpec.describe PlatformApis::Properties::Client do
       described_class.get_properties_by_postcode("E9 6PT")
     end
   end
+
+  describe ".get_property_by_reference" do
+    it "calls the Request object with a property reference id" do
+      expect(request).to receive(:retrieve).with("properties/100023022310")
+
+      described_class.get_property_by_reference("100023022310")
+    end
+  end
 end

--- a/spec/support/hackney_platform_api_request_stubs.rb
+++ b/spec/support/hackney_platform_api_request_stubs.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  helpers = Module.new do
+    def stub_properties_request(query_params:, response_body:, status:)
+      stub_request(
+        :get,
+        "#{Rails.application.credentials.platform_apis[:properties][:url]}properties"
+      ).with(
+        headers: { "X-Api-Key" => Rails.application.credentials.platform_apis[:properties][:x_api_key] },
+        query:   query_params
+      ).to_return(
+        body: JSON.generate(response_body),
+        status: status
+      )
+    end
+
+    def stub_property_request(reference:, response_body:, status:)
+      stub_request(
+        :get,
+        "#{Rails.application.credentials.platform_apis[:properties][:url]}properties/#{reference}"
+      ).with(
+        headers: { "X-Api-Key" => Rails.application.credentials.platform_apis[:properties][:x_api_key] },
+      ).to_return(
+        body: JSON.generate(response_body),
+        status: status
+      )
+    end
+  end
+
+  config.include helpers, type: :request
+end


### PR DESCRIPTION
### Description of change

- Adds integration with Hackney's Platform Property Information Api to fetch a single property given the property reference number e.g. `/api/v1/properties/100023022310`

- Properties#show to expose the endpoint

![Screenshot 2020-11-12 at 12 45 07](https://user-images.githubusercontent.com/34001723/98941786-f1a1fa80-24e4-11eb-9837-d3ad68251fe0.png)


### Story Link

The backend implementation to the story: https://trello.com/c/nS0rF2iL/153-5pts-as-a-user-i-need-to-see-the-address-postcode-and-property-type-so-that-i-know-what-property-im-looking-at
