### PR TITLE
Return first line of an address

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -3,21 +3,30 @@
 class Address
   include ActiveModel::Model
 
-  attr_accessor :shortAddress, :postalCode, :addressLine
+  attr_accessor :shortAddress, :postalCode, :addressLine, :streetSuffix
 
   class << self
     def build(attributes)
       new(
         shortAddress: attributes["address1"],
         postalCode: attributes["postCode"],
-        addressLine: address_line(attributes["address1"])
+        addressLine: split_address(attributes["address1"]).first,
+        streetSuffix: street_suffix(attributes["address1"])
       )
     end
 
   private
 
-    def address_line(address)
-      address.split("  ").first
+    def split_address(address)
+      address.split("  ")
+    end
+
+    def split_address?(address)
+      split_address(address).length > 1
+    end
+
+    def street_suffix(address)
+      split_address?(address) ? split_address(address).last : ""
     end
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -3,12 +3,21 @@
 class Address
   include ActiveModel::Model
 
-  attr_accessor :shortAddress, :postalCode
+  attr_accessor :shortAddress, :postalCode, :addressLine
 
-  def self.build(attributes)
-    new(
-      shortAddress: attributes["address1"],
-      postalCode: attributes["postCode"]
-    )
+  class << self
+    def build(attributes)
+      new(
+        shortAddress: attributes["address1"],
+        postalCode: attributes["postCode"],
+        addressLine: address_line(attributes["address1"])
+      )
+    end
+
+  private
+
+    def address_line(address)
+      address.split("  ").first
+    end
   end
 end

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe Property do
       expect(property.propertyReference).to eq "100023022310"
       expect(property.address.postalCode).to eq("E9 6PT")
       expect(property.address.shortAddress).to eq("16 Pitcairn House  St Thomass Square")
+      expect(property.address.addressLine).to eq("16 Pitcairn House")
       expect(property.hierarchyType.levelCode).to eq("7")
       expect(property.hierarchyType.subTypeCode).to eq("DWE")
       expect(property.hierarchyType.subTypeDescription).to eq("Dwelling")

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe Property do
       expect(property.address.postalCode).to eq("E9 6PT")
       expect(property.address.shortAddress).to eq("16 Pitcairn House  St Thomass Square")
       expect(property.address.addressLine).to eq("16 Pitcairn House")
+      expect(property.address.streetSuffix).to eq("St Thomass Square")
       expect(property.hierarchyType.levelCode).to eq("7")
       expect(property.hierarchyType.subTypeCode).to eq("DWE")
       expect(property.hierarchyType.subTypeDescription).to eq("Dwelling")

--- a/spec/requests/properties_spec.rb
+++ b/spec/requests/properties_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe "Properties" do
           {
             "propertyReference" => "001",
             "address" => {
+              "addressLine" => "1 Example Road",
               "shortAddress" => "1 Example Road",
               "postalCode" => "A1 1AA"
             },
@@ -69,6 +70,7 @@ RSpec.describe "Properties" do
           {
             "propertyReference" => "001",
             "address" => {
+              "addressLine" => "1 Example Road",
               "shortAddress" => "1 Example Road",
               "postalCode" => "A1 1AA"
             },
@@ -108,6 +110,7 @@ RSpec.describe "Properties" do
           {
             "propertyReference" => "001",
             "address" => {
+              "addressLine" => "1 Example Road",
               "shortAddress" => "1 Example Road",
               "postalCode" => "A1 1AA"
             },
@@ -148,6 +151,7 @@ RSpec.describe "Properties" do
           {
             "propertyReference" => "100023022310",
             "address" => {
+              "addressLine" => "1 Example Road",
               "shortAddress" => "1 Example Road",
               "postalCode" => "A1 1AA"
             },

--- a/spec/requests/properties_spec.rb
+++ b/spec/requests/properties_spec.rb
@@ -30,9 +30,10 @@ RSpec.describe "Properties" do
           {
             "propertyReference" => "001",
             "address" => {
-              "addressLine" => "1 Example Road",
               "shortAddress" => "1 Example Road",
-              "postalCode" => "A1 1AA"
+              "postalCode" => "A1 1AA",
+              "addressLine" => "1 Example Road",
+              "streetSuffix" => ""
             },
             "hierarchyType" => {
               "levelCode" => "1",
@@ -70,9 +71,10 @@ RSpec.describe "Properties" do
           {
             "propertyReference" => "001",
             "address" => {
-              "addressLine" => "1 Example Road",
               "shortAddress" => "1 Example Road",
-              "postalCode" => "A1 1AA"
+              "postalCode" => "A1 1AA",
+              "addressLine" => "1 Example Road",
+              "streetSuffix" => ""
             },
             "hierarchyType" => {
               "levelCode" => "1",
@@ -110,9 +112,10 @@ RSpec.describe "Properties" do
           {
             "propertyReference" => "001",
             "address" => {
-              "addressLine" => "1 Example Road",
               "shortAddress" => "1 Example Road",
-              "postalCode" => "A1 1AA"
+              "postalCode" => "A1 1AA",
+              "addressLine" => "1 Example Road",
+              "streetSuffix" => ""
             },
             "hierarchyType" => {
               "levelCode" => "1",
@@ -151,9 +154,10 @@ RSpec.describe "Properties" do
           {
             "propertyReference" => "100023022310",
             "address" => {
-              "addressLine" => "1 Example Road",
               "shortAddress" => "1 Example Road",
-              "postalCode" => "A1 1AA"
+              "postalCode" => "A1 1AA",
+              "addressLine" => "1 Example Road",
+              "streetSuffix" => ""
             },
             "hierarchyType" => {
               "levelCode" => "1",


### PR DESCRIPTION
1)
- Use HACT compliant `AddressLine` key name
- If there is a first line of an address, the  Platform (Property Information) API has the behaviour of adding two blank spaces after the first line of an address

2)
- Use HACT compliant `StreetSuffix` key name
- If there is a last line (street suffix) of an address, the Platform (Property Information) API has the behaviour of adding two blank spaces after the first line of an address and the address info after this space is the street suffix
- Return empty string if the address is not splittable


### Description of change

Adds `addressLine` key to address api response
Adds `streetSuffix` key to address api response

Example response:

When shortAddress is splittable:
![Screenshot 2020-11-19 at 17 32 40](https://user-images.githubusercontent.com/34001723/99702079-474e4800-2a8d-11eb-91e0-14c10d42580b.png)

When shortAddress is not splittable:
![Screenshot 2020-11-19 at 17 33 34](https://user-images.githubusercontent.com/34001723/99702293-8086b800-2a8d-11eb-9de6-78d75d8e9b8c.png)


### Story Link

Part of https://trello.com/c/nS0rF2iL/153-as-a-user-i-need-to-see-the-address-postcode-and-property-type-so-that-i-know-what-property-im-looking-at

### Decisions [OPTIONAL]

No consistent response from Property Information API for first line of address. Only reliable thing to use is `shortAddress` or `address1`
The previous repairs hub application used logic to find this by splitting the short address when there were two blank spaces and taking the first part as the address line