### PR TITLE
Switch to v2 of the API

### DIFF
--- a/app/controllers/api/v2/cautionary_alerts_controller.rb
+++ b/app/controllers/api/v2/cautionary_alerts_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Api
-  module V1
+  module V2
     class CautionaryAlertsController < ApplicationController
       def index
         @property = CautionaryAlert.for_property_reference(params[:property_id])

--- a/app/controllers/api/v2/properties_controller.rb
+++ b/app/controllers/api/v2/properties_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Api
-  module V1
+  module V2
     class PropertiesController < ApplicationController
       def index
         @properties = PropertiesSearch.new(params).perform

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 
 Rails.application.routes.draw do
   namespace :api do
-    namespace :v1 do
+    namespace :v2 do
       resources :properties, only: %i(index show) do
         resources :cautionary_alerts, path: "/cautionary-alerts", only: [:index]
       end

--- a/spec/requests/cautionary_alerts_spec.rb
+++ b/spec/requests/cautionary_alerts_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "CautionaryAlerts" do
           status: 200
         )
 
-        get("/api/v1/properties/0001234/cautionary-alerts", headers: headers)
+        get("/api/v2/properties/0001234/cautionary-alerts", headers: headers)
       end
 
       it "returns a JSON representation from a single property" do
@@ -60,7 +60,7 @@ RSpec.describe "CautionaryAlerts" do
           status: 200
         )
 
-        get("/api/v1/properties/0001234/cautionary-alerts", headers: headers)
+        get("/api/v2/properties/0001234/cautionary-alerts", headers: headers)
       end
 
       it "returns a JSON representation from a single property" do
@@ -94,7 +94,7 @@ RSpec.describe "CautionaryAlerts" do
           status: 200
         )
 
-        get("/api/v1/properties/0001234/cautionary-alerts", headers: nil)
+        get("/api/v2/properties/0001234/cautionary-alerts", headers: nil)
       end
 
       it "returns invalid auth token error message" do
@@ -125,7 +125,7 @@ RSpec.describe "CautionaryAlerts" do
           status: 200
         )
 
-        get("/api/v1/properties/0001234/cautionary-alerts", headers: headers)
+        get("/api/v2/properties/0001234/cautionary-alerts", headers: headers)
       end
 
       it "returns couldn't find ApiClient error message" do

--- a/spec/requests/properties_spec.rb
+++ b/spec/requests/properties_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Properties" do
           status: 200
         )
 
-        get("/api/v1/properties", params: { postcode: "A1 1AA" }, headers: headers)
+        get("/api/v2/properties", params: { postcode: "A1 1AA" }, headers: headers)
       end
 
       it "returns JSON representations of properties" do
@@ -64,7 +64,7 @@ RSpec.describe "Properties" do
           status: 200
         )
 
-        get("/api/v1/properties", params: { address: "1 Example Road" }, headers: headers)
+        get("/api/v2/properties", params: { address: "1 Example Road" }, headers: headers)
       end
 
       it "returns JSON representations of properties" do
@@ -105,7 +105,7 @@ RSpec.describe "Properties" do
           status: 200
         )
 
-        get("/api/v1/properties", params: { q: "1 Example Road" }, headers: headers)
+        get("/api/v2/properties", params: { q: "1 Example Road" }, headers: headers)
       end
 
       it "returns JSON representations of properties" do
@@ -146,7 +146,7 @@ RSpec.describe "Properties" do
           status: 200
         )
 
-        get("/api/v1/properties", params: { postcode: "A1 1AA" }, headers: nil)
+        get("/api/v2/properties", params: { postcode: "A1 1AA" }, headers: nil)
       end
 
       it "returns JSON representations of properties" do
@@ -174,7 +174,7 @@ RSpec.describe "Properties" do
           status: 200
         )
 
-        get("/api/v1/properties", params: { postcode: "A1 1AA" }, headers: headers)
+        get("/api/v2/properties", params: { postcode: "A1 1AA" }, headers: headers)
       end
 
       it "returns JSON representations of properties" do
@@ -201,7 +201,7 @@ RSpec.describe "Properties" do
           status: 200
         )
 
-        get("/api/v1/properties/100023022310", headers: headers)
+        get("/api/v2/properties/100023022310", headers: headers)
       end
 
       it "returns a JSON representation from a single property" do


### PR DESCRIPTION
### Description of change

Switch to v2 of the API

Since there is a Hackney Repairs API v1, is better to be
consistent and name this as v2.