### PR TITLE
Handle errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -88,7 +88,7 @@ Layout/LeadingCommentSpace:
   Enabled: true
 
 Layout/LineLength:
-  Max: 80
+  Max: 120
   Exclude:
     - "spec/**/*"
 
@@ -158,7 +158,7 @@ Lint/UriEscapeUnescape:
 
 # Don't worry about long methods in specs.
 Metrics/MethodLength:
-  Max: 10
+  Max: 14
   Exclude:
     - "spec/**/*"
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@
 class ApplicationController < ActionController::API
   before_action :authenticate_token!
 
+  include Api::ErrorHandler
+
   def authenticate_token!
     payload = JsonWebToken.decode(auth_token)
     ApiClient.find_by!(

--- a/app/controllers/concerns/api/error_handler.rb
+++ b/app/controllers/concerns/api/error_handler.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Api::ErrorHandler
+  extend ActiveSupport::Concern
+  include HttpStatusCodes
+
+  included do
+    rescue_from Request::RecordNotFoundError, with: :error_as_json
+    rescue_from Request::TimeoutError, with: :error_as_json
+    rescue_from Request::ApiError, with: :error_as_json
+
+  private
+
+    def error_as_json(error)
+      error_hash = eval(error.message)
+
+      render json: {
+        errors: [
+          {
+            title: error_hash[:message]["title"] || error_hash[:message],
+            status: error_hash[:status] || API_ERROR
+          }
+        ]
+      }, status: error_hash[:status] || API_ERROR
+    end
+  end
+end

--- a/app/lib/http_status_codes.rb
+++ b/app/lib/http_status_codes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module HttpStatusCodes
+  OK = 200
+  NO_CONTENT = 204
+  NOT_FOUND = 404
+  API_ERROR = 500
+  TIMEOUT_ERROR = 504
+  UNAUTHORIZED = 401
+end

--- a/app/models/cautionary_alert.rb
+++ b/app/models/cautionary_alert.rb
@@ -10,7 +10,7 @@ class CautionaryAlert
       response = PlatformApis::CautionaryAlerts::Client.
         get_cautionary_alerts_by_property_reference(reference)
 
-      response.key?(:message) ? [] : build(response)
+      build(response)
     end
 
     def build(attributes)

--- a/app/services/request.rb
+++ b/app/services/request.rb
@@ -1,20 +1,40 @@
 # frozen_string_literal: true
 
 class Request
+  include HttpStatusCodes
+
+  class PlatformApiError < StandardError; end
+  class RecordNotFoundError < PlatformApiError; end
+  class TimeoutError < PlatformApiError; end
+  class UnauthorizedError < PlatformApiError; end
+  class ApiError < PlatformApiError; end
+
   def initialize(connection)
     @connection = connection
   end
 
   def retrieve(path)
     response, status = get_json(path)
-    status == 200 ? response : errors(response)
+
+    case status
+    when OK, NO_CONTENT
+      response
+    when NOT_FOUND
+      raise RecordNotFoundError, errors(response, status)
+    when UNAUTHORIZED
+      raise UnauthorizedError, errors(response, status)
+    when TIMEOUT_ERROR
+      raise TimeoutError, errors(response, status)
+    else
+      raise ApiError, errors(response, status)
+    end
   end
 
 private
   attr_reader :connection
 
-  def errors(response)
-    { message: response["message"] }
+  def errors(response, status)
+    { message: response, status: status }
   end
 
   def get_json(path)

--- a/spec/requests/cautionary_alerts_spec.rb
+++ b/spec/requests/cautionary_alerts_spec.rb
@@ -134,5 +134,32 @@ RSpec.describe "CautionaryAlerts" do
         expect(parsed_response.first).to eq(["errors", "Couldn't find ApiClient"])
       end
     end
+
+    context "when searching by a property reference that has no alerts" do
+      before do
+        stub_cautionary_alerts_property_request(
+          reference: "0123",
+          response_body: "Property cautionary alert(s) for property reference 0123 not found",
+          status: 404
+        )
+
+        get("/api/v2/properties/0123/cautionary-alerts", headers: headers)
+      end
+
+      it "returns error hash response" do
+        parsed_response = JSON.parse(response.body)
+
+        expect(parsed_response).to eq(
+          {
+            "errors" => [
+              {
+                "status" => 404,
+                "title" => "Property cautionary alert(s) for property reference 0123 not found"
+              }
+            ]
+          }
+        )
+      end
+    end
   end
 end

--- a/spec/requests/properties_spec.rb
+++ b/spec/requests/properties_spec.rb
@@ -225,5 +225,36 @@ RSpec.describe "Properties" do
         )
       end
     end
+
+    context "when searching by an invalid property reference" do
+      before do
+        stub_property_request(
+          reference: "124124241",
+          response_body:
+            {
+              "title": "Not Found",
+              "status": 404
+            },
+          status: 404
+        )
+
+        get("/api/v2/properties/124124241", headers: headers)
+      end
+
+      it "returns error hash response" do
+        parsed_response = JSON.parse(response.body)
+
+        expect(parsed_response).to eq(
+          {
+            "errors" => [
+              {
+                "status" => 404,
+                "title" => "Not Found"
+              }
+            ]
+          }
+        )
+      end
+    end
   end
 end

--- a/spec/services/request_spec.rb
+++ b/spec/services/request_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Request do
 
     subject { described_class.new(connection) }
 
-    context "when the response code is 200" do
+    context "when the response code is 200 (OK)" do
       let(:response) do
         double(
           status: 200,
@@ -26,18 +26,83 @@ RSpec.describe Request do
       end
     end
 
-    context "when the response code is not 200" do
+    context "when the response code is 400 (Bad Request)" do
       let(:response) do
         double(
           status: 400,
-          body: "{\"message\":\"Forbidden\"}"
+          body: "\"Bad request\""
         )
       end
 
       it "returns a parsed JSON response body message" do
-        expect(subject.retrieve(path)).to eq(
-          { message: "Forbidden" }
+        expect {
+          subject.retrieve(path)
+        }.to raise_error(described_class::ApiError).
+         with_message("{:message=>\"Bad request\", :status=>400}")
+      end
+    end
+
+    context "when the response code is 403 (Forbidden)" do
+      let(:response) do
+        double(
+          status: 403,
+          body: "\"Forbidden\""
         )
+      end
+
+      it "returns a parsed JSON response body error message with status" do
+        expect {
+          subject.retrieve(path)
+        }.to raise_error(described_class::ApiError).
+         with_message("{:message=>\"Forbidden\", :status=>403}")
+      end
+    end
+
+    context "when the response code is 404 (Not Found)" do
+      let(:response) do
+        double(
+          status: 404,
+          body: "\"Record not found\""
+        )
+      end
+
+      it "returns a parsed JSON response body error message with status" do
+        expect {
+          subject.retrieve(path)
+        }.to raise_error(described_class::RecordNotFoundError).
+         with_message("{:message=>\"Record not found\", :status=>404}")
+      end
+    end
+
+    context "when the response code is 500 (API Error)" do
+      let(:response) do
+        double(
+          status: 500,
+          body: "\"API error\""
+        )
+      end
+
+      it "returns a parsed JSON response body error message with status" do
+        expect {
+          subject.retrieve(path)
+        }.to raise_error(described_class::ApiError).
+         with_message("{:message=>\"API error\", :status=>500}")
+      end
+    end
+
+    context "when the response code is 504 (Timeout Error)" do
+      let(:response) do
+        double(
+          status: 504,
+          body: "\"Timeout Error\""
+        )
+      end
+
+      it "returns a parsed JSON response body error message with status" do
+        expect {
+          subject.retrieve(path)
+        }.to raise_error(described_class::TimeoutError).
+         with_message("{:message=>\"Timeout Error\", :status=>504}")
       end
     end
   end


### PR DESCRIPTION
### Description of change

Raise errors in line with Platform API response status and rescue to display a json error message with the relevant status code