### PR TITLE
Add canRaiseRepair boolean field on tenure object response

### DIFF
--- a/app/models/tenure.rb
+++ b/app/models/tenure.rb
@@ -3,7 +3,10 @@
 class Tenure
   include ActiveModel::Model
 
-  attr_accessor :typeCode, :typeDescription
+  # Raisable tenure codes taken from Repairs Hub V1
+  RAISABLE_TENURES = %w(ASY COM DEC INT MPA NON PVG SEC TAF TGA TRA)
+
+  attr_accessor :typeCode, :typeDescription, :canRaiseRepair
 
   class << self
     def find_tenure_type(reference)
@@ -21,8 +24,13 @@ class Tenure
     def build(attribute)
       new(
         typeCode: attribute.split(": ").first,
-        typeDescription: attribute.split(": ").last
+        typeDescription: attribute.split(": ").last,
+        canRaiseRepair: can_raise_a_repair?(attribute.split(": ").first)
       )
+    end
+
+    def can_raise_a_repair?(tenure_code)
+      RAISABLE_TENURES.include?(tenure_code)
     end
   end
 end

--- a/spec/integration/properties_spec.rb
+++ b/spec/integration/properties_spec.rb
@@ -143,7 +143,8 @@ RSpec.describe "Properties API" do
             type: :object,
             properties: {
               typeCode: { type: :string },
-              typeDescription: { type: :string }
+              typeDescription: { type: :string },
+              canRaiseRepair: { type: :boolean }
             }
           }
         }

--- a/spec/models/tenure_spec.rb
+++ b/spec/models/tenure_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tenure do
+  let(:tenure_attributes) do
+    {
+      "tenancies" => [
+        {
+          "tenancyAgreementReference" => "011111/01",
+          "tenureType" => "SEC: Secure"
+        }
+      ]
+    }
+  end
+
+  describe ".find_tenure_type" do
+    let(:reference) { "100023022310" }
+
+    it "returns a tenure object built from the API client response" do
+      allow(PlatformApis::TenancyInformation::Client).to receive(
+        :get_tenancy_information_by_property_reference
+      ).with(reference).and_return(
+        tenure_attributes
+      )
+
+      tenure = described_class.find_tenure_type(reference)
+
+      expect(tenure.typeCode).to eq "SEC"
+      expect(tenure.typeDescription).to eq("Secure")
+      expect(tenure.canRaiseRepair).to eq(true)
+    end
+  end
+
+  describe ".build" do
+    it "builds a new tenure with supplied attributes" do
+      tenure = described_class.build(tenure_attributes["tenancies"].first["tenureType"])
+
+      expect(tenure.typeCode).to eq "SEC"
+      expect(tenure.typeDescription).to eq("Secure")
+      expect(tenure.canRaiseRepair).to eq(true)
+    end
+  end
+
+  describe ".can_raise_a_repair?" do
+    Tenure::RAISABLE_TENURES.each do |tenure_code|
+      it "returns true for the tenure code: #{tenure_code} which can raise a repair" do
+        expect(described_class.can_raise_a_repair?(tenure_code)).to eq(true)
+      end
+    end
+
+    # Non raisable tenure codes taken from Repairs Hub V1
+    %w(FRE FRS HPH LEA LHS LTA RSL RTM SHO SLL SMW SPS SPT SSE TBB THA THL THO TLA TPL).each do |tenure_code|
+      it "returns false for the tenure code: #{tenure_code} which can not raise a repair" do
+        expect(described_class.can_raise_a_repair?(tenure_code)).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/requests/properties_spec.rb
+++ b/spec/requests/properties_spec.rb
@@ -204,6 +204,19 @@ RSpec.describe "Properties" do
 
       context "with tenancy information details" do
         before do
+          stub_property_request(
+            reference: "100023022310",
+            response_body:
+              {
+                propRef: "100023022310",
+                address1: "1 Example Road",
+                postCode: "A1 1AA",
+                levelCode: "1",
+                subtypCode: "DWE"
+              },
+            status: 200
+          )
+
           stub_alerts_property_request(
             reference: "100023022310",
             response_body:
@@ -317,18 +330,31 @@ RSpec.describe "Properties" do
 
       context "with no tenancy information details" do
         before do
-          stub_alerts_property_request(
-            reference: "100023022310",
+          stub_property_request(
+            reference: "100012345678",
             response_body:
               {
-                "propertyReference": "100023022310",
+                propRef: "100012345678",
+                address1: "1 Example Road",
+                postCode: "A1 1AA",
+                levelCode: "1",
+                subtypCode: "DWE"
+              },
+            status: 200
+          )
+
+          stub_alerts_property_request(
+            reference: "100012345678",
+            response_body:
+              {
+                "propertyReference": "100012345678",
                 "alerts": []
               },
             status: 200
           )
 
           stub_tenancy_information_property_request(
-            reference: "100023022310",
+            reference: "100012345678",
             response_body:
               {
                 "tenancies": []
@@ -336,7 +362,7 @@ RSpec.describe "Properties" do
             status: 200
           )
 
-          get("/api/v2/properties/100023022310", headers: headers)
+          get("/api/v2/properties/100012345678", headers: headers)
         end
 
         it "returns a JSON representation from a single property with no tenure details and no alerts" do
@@ -344,7 +370,7 @@ RSpec.describe "Properties" do
 
           expect(parsed_response).to eq(
             "property" => {
-              "propertyReference" => "100023022310",
+              "propertyReference" => "100012345678",
               "address" => {
                 "shortAddress" => "1 Example Road",
                 "postalCode" => "A1 1AA",

--- a/spec/requests/properties_spec.rb
+++ b/spec/requests/properties_spec.rb
@@ -322,7 +322,8 @@ RSpec.describe "Properties" do
             },
             "tenure" => {
               "typeCode" => "SEC",
-              "typeDescription" => "Secure"
+              "typeDescription" => "Secure",
+              "canRaiseRepair" => true
             }
           )
         end

--- a/swagger/v2/swagger.yaml
+++ b/swagger/v2/swagger.yaml
@@ -145,6 +145,8 @@ paths:
                         type: string
                       typeDescription:
                         type: string
+                      canRaiseRepair:
+                        type: boolean
         '401':
           description: Invalid auth token
           content:


### PR DESCRIPTION
### Description of change

- Add canRaiseRepair boolean field on tenure object response
- Use tenure codes from repairs hub v1 to determine whether a repair is raisable or not (need to check if this is still valid)

### Story Link

https://trello.com/c/3yBCDiDd/157-as-a-user-i-need-to-know-if-we-are-liable-for-repairs-at-this-property-so-i-dont-raise-a-repair-unnecessarily

### Decisions [OPTIONAL]

- Better to implement this logic on the API side rather than in the frontend


